### PR TITLE
Bump GH Actions versions (Go; node12 deprecation)

### DIFF
--- a/.github/workflows/go-client-tests-ubuntu.yml
+++ b/.github/workflows/go-client-tests-ubuntu.yml
@@ -11,9 +11,9 @@ jobs:
       GODEBUG: x509sha1=1
     steps:
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: '1.19.9'
       - name: Install Nats Server
         run: |
           cd $GITHUB_WORKSPACE
@@ -27,7 +27,7 @@ jobs:
           rm -rf nats-server
           nats-server -v
       - name: Check out Go client code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: nats-io/nats.go
       - name: Go Get Stuff

--- a/.github/workflows/go-client-tests-windows.yml
+++ b/.github/workflows/go-client-tests-windows.yml
@@ -11,9 +11,9 @@ jobs:
       GODEBUG: x509sha1=1
     steps:
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: '1.19.9'
       - name: Install Nats Server
         run: |
           git clone https://github.com/nats-io/nats-server.git
@@ -26,7 +26,7 @@ jobs:
           nats-server -v
         shell: cmd
       - name: Check out Go client code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: nats-io/nats.go
       - name: Go Get Stuff

--- a/.github/workflows/integration-tests-ubuntu.yml
+++ b/.github/workflows/integration-tests-ubuntu.yml
@@ -16,9 +16,9 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: '1.19.9'
       - name: Install Nats Server
         run: |
           cd $GITHUB_WORKSPACE
@@ -32,7 +32,7 @@ jobs:
           rm -rf nats-server
           nats-server -v
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Java Integration Tests
         run: |
           pushd java-integration-tests

--- a/.github/workflows/integration-tests-windows.yml
+++ b/.github/workflows/integration-tests-windows.yml
@@ -16,11 +16,11 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: '1.19.9'
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Java Integration Tests
         run: |
           cd %GITHUB_WORKSPACE%\java-integration-tests

--- a/.github/workflows/java-client-tests-ubuntu.yml
+++ b/.github/workflows/java-client-tests-ubuntu.yml
@@ -16,9 +16,9 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: '1.19.9'
       - name: Install Nats Server
         run: |
           cd $GITHUB_WORKSPACE
@@ -32,7 +32,7 @@ jobs:
           rm -rf nats-server
           nats-server -v
       - name: Check out Java client code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: nats-io/nats.java
       - name: Run Client Unit Tests

--- a/.github/workflows/java-client-tests-windows.yml
+++ b/.github/workflows/java-client-tests-windows.yml
@@ -16,11 +16,11 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: '1.19.9'
       - name: Check out Java client code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: nats-io/nats.java
       - name: Install Nats Server

--- a/.github/workflows/java-regression-tests-ubuntu-284.yml
+++ b/.github/workflows/java-regression-tests-ubuntu-284.yml
@@ -16,9 +16,9 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: '1.19.9'
       - name: Install Nats Server
         run: |
           cd $GITHUB_WORKSPACE
@@ -33,7 +33,7 @@ jobs:
           rm -rf nats-server
           nats-server -v
       - name: Check out Java client code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: nats-io/nats.java
       - name: Run Client Unit Tests

--- a/.github/workflows/java-regression-tests-ubuntu-dev.yml
+++ b/.github/workflows/java-regression-tests-ubuntu-dev.yml
@@ -16,9 +16,9 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: '1.19.9'
       - name: Install Nats Server
         run: |
           cd $GITHUB_WORKSPACE
@@ -33,7 +33,7 @@ jobs:
           rm -rf nats-server
           nats-server -v
       - name: Check out Java client code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: nats-io/nats.java
       - name: Run Client Unit Tests

--- a/.github/workflows/java-regression-tests-windows-284.yml
+++ b/.github/workflows/java-regression-tests-windows-284.yml
@@ -16,11 +16,11 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: '1.19.9'
       - name: Check out Java client code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: nats-io/nats.java
       - name: Install Nats Server

--- a/.github/workflows/java-regression-tests-windows-dev.yml
+++ b/.github/workflows/java-regression-tests-windows-dev.yml
@@ -16,11 +16,11 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: '1.19.9'
       - name: Check out Java client code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: nats-io/nats.java
       - name: Install Nats Server


### PR DESCRIPTION
Bump two GitHub Actions versions to move away from the deprecated node.js 12 bases and so reduce warning noise in Actions output:

    actions/setup-go v2 -> v3
    actions/checkout v2 -> v3

Bump Golang version 1.19.2 to 1.19.9; also, quote the string for defensiveness against version number parsing and YAML string vs version numbers.  While we're unlikely to switch to patch-level-unspecified in future, protect against mistakes by quoting, as we're doing for all repos.
